### PR TITLE
TDQ-10981: Proposal of fixes for initial implementation

### DIFF
--- a/main/plugins/org.talend.dataquality.common/src/main/java/org/talend/datascience/common/inference/Analyzers.java
+++ b/main/plugins/org.talend.dataquality.common/src/main/java/org/talend/datascience/common/inference/Analyzers.java
@@ -17,27 +17,30 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.log4j.Logger;
 
 /**
- * Provides a way to combine several {@link Analyzer<?>} together and a
+ * Provides a way to combine several {@link Analyzer} together and a
  * {@link org.talend.datascience.common.inference.Analyzers.Result result} that stores all underlying results.
  *
- * @see #with(Analyzer<?>[])
+ * @see #with(Analyzer[])
  */
 public class Analyzers implements Analyzer<Analyzers.Result> {
 
     private static final long serialVersionUID = 3718737129904789140L;
 
+    private static final Logger LOGGER = Logger.getLogger(Analyzers.class);
+
     private final Analyzer<?>[] analyzers;
 
-    private final ResizableList<Result> results = new ResizableList<Result>(Result.class);
+    private final ResizableList<Result> results = new ResizableList<>(Result.class);
 
     private Analyzers(Analyzer<?>... analyzers) {
         this.analyzers = analyzers;
     }
 
     /**
-     * Creates a single analyzer with provided {@link Analyzer<?> analyzers}.
+     * Creates a single analyzer with provided {@link Analyzer analyzers}.
      * 
      * @param analyzers The analyzers to be combined together.
      * @return A single analyzer that ensure all underlying analyzers get called.
@@ -84,7 +87,7 @@ public class Analyzers implements Analyzer<Analyzers.Result> {
      */
     public static class Result {
 
-        private final Map<Class<?>, Object> results = new HashMap<Class<?>, Object>();
+        private final Map<Class<?>, Object> results = new HashMap<>();
 
         public <T> T get(Class<T> clazz) {
             if (results.containsKey(clazz)) {
@@ -109,6 +112,13 @@ public class Analyzers implements Analyzer<Analyzers.Result> {
 
     @Override
     public void close() throws Exception {
+        for (Analyzer<?> analyzer : analyzers) {
+            try {
+                analyzer.close();
+            } catch (Exception e) {
+                LOGGER.error("Unable to close " + analyzer, e);
+            }
+        }
     }
     
 }


### PR DESCRIPTION
* Analyzers::close() should call close() on wrapped analyzers to fulfill close() contract.
* ConcurrentAnalyzer: prefer a ThreadLocal+ObjectPool solution to allow re-entry and reuse of the *same* Analyzer instance throughout all analysis.
* ClassPathDirectory: each ClassPathDirectory instance now uses its own temp directory iso. shared one.
* ConcurrentAnalyzerTest: amend test as there were testing the correct operation sequence (missing call to close() aimed to be the method to return an object to the pool).