### PR TITLE
Fix TUP-24170 Set crypto-utils as bundle to make the master compile with daikon 0.31.10-SNAPSHOT

### DIFF
--- a/main/features/org.talend.top.feature/feature.xml
+++ b/main/features/org.talend.top.feature/feature.xml
@@ -35,6 +35,7 @@
     <import plugin="org.apache.servicemix.bundles.avro" version="0.0.0" match="greaterOrEqual"/>
     <import plugin="org.eclipse.nebula.widgets.nattable.core" version="0.0.0" match="greaterOrEqual"/>
     <import plugin="org.ops4j.pax.url.mvn" version="0.0.0" match="greaterOrEqual"/>
+    <import plugin="org.apache.commons.configuration" version="2.0.0" match="greaterOrEqual"/>
   </requires>
   <plugin id="org.talend.cwm.compare" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
   <plugin id="org.talend.cwm.compare.nl" download-size="0" install-size="0" version="0.0.0" fragment="true" unpack="false"/>

--- a/main/features/org.talend.top.feature/feature.xml
+++ b/main/features/org.talend.top.feature/feature.xml
@@ -45,6 +45,7 @@
   <plugin id="org.talend.cwm.mip.edit.nl" download-size="0" install-size="0" version="0.0.0" fragment="true" unpack="false"/>
   <plugin id="org.talend.cwm.mip.nl" download-size="0" install-size="0" version="0.0.0" fragment="true" unpack="false"/>
   <plugin id="org.talend.daikon" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+  <plugin id="org.talend.daikon.crypto.utils" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
   <plugin id="org.talend.daikon.exception" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
   <plugin id="org.talend.dataprofiler.common.ui" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
   <plugin id="org.talend.dataprofiler.common.ui.nl" download-size="0" install-size="0" version="0.0.0" fragment="true" unpack="false"/>


### PR DESCRIPTION
Fix TUP-24170 Set crypto-utils as bundle to make the master compile with daikon 0.31.10-SNAPSHOT
https://jira.talendforge.org/browse/TUP-24170