### PR TITLE
fix(TDQ-18018)Avoid to call

### DIFF
--- a/main/plugins/org.talend.dataprofiler.core/src/org/talend/dataprofiler/core/manager/DQStructureManager.java
+++ b/main/plugins/org.talend.dataprofiler.core/src/org/talend/dataprofiler/core/manager/DQStructureManager.java
@@ -419,7 +419,9 @@ public final class DQStructureManager {
                     String extendtion = name.substring(indexOf + 1);
                     createSourceFileItem(file, Path.EMPTY, label, extendtion);
                 } else {
-                    copyFileToFolder(openStream, fileName, folder);
+                    // TDQ-18018 Add parameter 'import' as true so as to avoid to call ProxyRepositoryFactory 335
+                    // "checkIfHaveDuplicateName(...)" make not change SystemIndicator path to empty
+                    copyFileToFolder(openStream, fileName, folder, true);
                 }
 
                 openStream.close();


### PR DESCRIPTION
'ProxyRepositoryFactory.checkIfHaveDuplicateName()' when copy DQ
structure files